### PR TITLE
投稿の詳細ページを追加

### DIFF
--- a/src/app/maps/[id]/page.tsx
+++ b/src/app/maps/[id]/page.tsx
@@ -1,0 +1,18 @@
+import PostDetails from '@/components/post/details';
+import { createClient } from '@/utils/supabase/server';
+
+export default async function GetPost({ params }: { params: { id: string } }) {
+  const supabase = createClient();
+
+  const { data } = await supabase
+    .from('posts')
+    .select('*')
+    .eq('id', params.id)
+    .single();
+
+  return (
+    <div className="relative flex h-full flex-col bg-stone-200">
+      <PostDetails post={data} />
+    </div>
+  );
+}

--- a/src/app/maps/page.tsx
+++ b/src/app/maps/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import Posts from '@/components/posts';
+import Posts from '@/components/post';
 import { useActionContext } from '@/context/actionContext';
 
 const Map = dynamic(() => import('@/components/maps'), { ssr: false });

--- a/src/components/container/index.tsx
+++ b/src/components/container/index.tsx
@@ -15,7 +15,7 @@ export default function Container({
 
 function NotSupported() {
   return (
-    <div className="flex h-full w-full items-center justify-center">
+    <div className="z-[9999] flex h-full w-full items-center justify-center">
       <div className="flex flex-col items-center space-y-4">
         <Icon />
         <p className="text-center font-semibold">

--- a/src/components/maps/index.tsx
+++ b/src/components/maps/index.tsx
@@ -3,8 +3,23 @@ import { MapContainer, TileLayer } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import './style.css';
 import MarkerEvent from './events/MarkerEvent';
+import { useMap } from 'react-leaflet';
+import L from 'leaflet';
 
-export default function Map() {
+function FlyToLocation({ pinnedLocation }: { pinnedLocation?: string }) {
+  const map = useMap();
+
+  if (pinnedLocation) {
+    const location = pinnedLocation.split(',');
+
+    L.marker([Number(location[0]), Number(location[1])]).addTo(map);
+    map.flyTo([Number(location[0]), Number(location[1])]);
+  }
+
+  return null;
+}
+
+export default function Map(props: { pinnedLocation?: string }) {
   return (
     <div className="flex h-full flex-col">
       <MapContainer
@@ -18,6 +33,7 @@ export default function Map() {
         />
         <Navigation />
         <MarkerEvent />
+        <FlyToLocation pinnedLocation={props.pinnedLocation} />
       </MapContainer>
     </div>
   );

--- a/src/components/navigationbar/index.tsx
+++ b/src/components/navigationbar/index.tsx
@@ -59,7 +59,7 @@ export default function Navigation() {
     <>
       <div
         id="navigation"
-        className="absolute top-5 z-[9999] mb-8 flex w-full items-end justify-between px-5"
+        className="absolute top-5 z-[9998] mb-8 flex w-full items-end justify-between px-5"
       >
         {map && (
           <div className="flex flex-col items-center rounded-xl bg-white p-2">

--- a/src/components/post/details.tsx
+++ b/src/components/post/details.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { Cat, Dog } from 'lucide-react';
+import dynamic from 'next/dynamic';
+const Map = dynamic(() => import('@/components/maps'), { ssr: false });
+
+export default function PostDetails(props: any) {
+  return (
+    <div className="relative z-[9998] flex h-full flex-col bg-stone-200">
+      <Map pinnedLocation={props.post.location} />
+      <div className="absolute bottom-0 left-0 z-[99999] flex w-full flex-col">
+        <div className="h-1/2 overflow-scroll p-5 px-5">
+          <div className="rounded-xl bg-white p-5">
+            <div className="max-w-full">
+              <h1 className="mb-4 text-2xl font-bold">{props.post.name}</h1>
+
+              <p className="py-2"> {props.post.description}</p>
+              <div className="flex">
+                <p className="px-2">一緒にに行けるどうぶつ</p>
+
+                {props.post.animals.includes('犬') ? <Dog /> : ''}
+                {props.post.animals.includes('猫') ? <Cat /> : ''}
+              </div>
+
+              <p className="py-2"> {props.post.keywords}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -4,7 +4,7 @@ import { useMarkerContext } from '@/context/markerContext';
 import { createClient } from '@/utils/supabase/client';
 import { useActionContext } from '@/context/actionContext';
 import { useState } from 'react';
-import { X, XIcon } from 'lucide-react';
+import { XIcon } from 'lucide-react';
 
 export default function Posts() {
   const supabase = createClient();
@@ -33,12 +33,17 @@ export default function Posts() {
       return;
     }
 
+    const locationText = `${markerLocation.lat},${markerLocation.lng}`.replace(
+      'undefined',
+      '',
+    );
+
     const { data, error } = await supabase.from('posts').insert([
       {
         name,
         animals: category,
         description,
-        location: `${markerLocation.lat},${markerLocation.lng}`,
+        location: locationText,
         keywords: nowLocation,
         google_map_url: url,
         created_at: new Date(),
@@ -59,7 +64,7 @@ export default function Posts() {
   };
 
   return (
-    <div className="absolute bottom-0 left-0 z-[99999] flex w-full flex-col">
+    <div className="absolute bottom-0 left-0 z-[9998] flex w-full flex-col">
       <div className="h-1/2 overflow-scroll p-5 px-5">
         <div className="rounded-xl bg-white p-5">
           <div className="flex max-w-full">


### PR DESCRIPTION
#67 
変更点

- components/posts をcomponents/post に変更 ←投稿を作成するコンポーネントなのでpostsよりpostのほうが正確?
- maps/[id]で投稿の詳細を表示
- markerLocation.lat か markerLocation.lngがundefinedだった場合空文字に置き換え
- navigationと投稿フォームのz-indexを調整